### PR TITLE
Hours tracking workaround 

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,9 +39,9 @@ var pages = {
   "/sponsor": ["sponsor.html"],
   "/contact": ["contact.html"],
   "/calendar": ["calendar.html"],
-  // "/hours": ["hours/auth.html"],
-  // "/hours/home": ["hours/home.html", getPeopleInjection],
-  // "/hours/people": ["hours/people.html", getPeopleInjection],
+  "/hours": ["hours/auth.html"],
+  "/hours/home": ["hours/home.html", getPeopleInjection],
+  "/hours/people": ["hours/people.html", getPeopleInjection],
   "/thankyou": ["thankyou.html"],
   "/dashboard": ["dashboard2.html"],
   //"/store": ["store.html"],
@@ -50,92 +50,92 @@ var pages = {
   // "/joinus": ["joinus.html"]
 };
 
-// //Hours Auth Middleware
-// app.use('/hours**', cookieParser(cookieSecret), (req, res, next) => {
-//   //first time auth with query
-//   if (Object.keys(req.query).length > 0 && req.query.password) {
-//     // @ts-ignore
-//     if (crypto.createHash('sha256').update(req.query.password).digest('hex') === hoursPasswordHash) {
-//       //save password in signed cookie
-//       res.cookie('password', req.query.password, {
-//         signed: true
-//       });
+//Hours Auth Middleware
+app.use('/hours**', cookieParser(cookieSecret), (req, res, next) => {
+  //first time auth with query
+  if (Object.keys(req.query).length > 0 && req.query.password) {
+    // @ts-ignore
+    if (crypto.createHash('sha256').update(req.query.password).digest('hex') === hoursPasswordHash) {
+      //save password in signed cookie
+      res.cookie('password', req.query.password, {
+        signed: true
+      });
 
-//       //go home timmy
-//       res.redirect('/hours/home');
-//     } else {
-//       //clear invalid query
-//       res.redirect('/hours');
-//     }
-//   }
+      //go home timmy
+      res.redirect('/hours/home');
+    } else {
+      //clear invalid query
+      res.redirect('/hours');
+    }
+  }
 
-//   //cashed auth with cookie
-//   else if (req.signedCookies && req.signedCookies.password &&
-//     crypto.createHash('sha256').update(req.signedCookies.password).digest('hex') === hoursPasswordHash) {
-//     if (req.baseUrl === '/hours') {
-//       //go home timmy
-//       res.redirect('/hours/home');
-//     } else {
-//       //let the king pass
-//       next();
-//     }
-//   }
+  //cashed auth with cookie
+  else if (req.signedCookies && req.signedCookies.password &&
+    crypto.createHash('sha256').update(req.signedCookies.password).digest('hex') === hoursPasswordHash) {
+    if (req.baseUrl === '/hours') {
+      //go home timmy
+      res.redirect('/hours/home');
+    } else {
+      //let the king pass
+      next();
+    }
+  }
 
-//   //invalid auth
-//   else {
-//     //remove invalid cookie
-//     res.clearCookie('password', {
-//       signed: true
-//     });
+  //invalid auth
+  else {
+    //remove invalid cookie
+    res.clearCookie('password', {
+      signed: true
+    });
 
-//     if (req.baseUrl === '/hours') {
-//       //let the peasant pass
-//       next();
-//     } else {
-//       //send to get auth
-//       res.redirect('/hours');
-//     }
-//   }
-// });
+    if (req.baseUrl === '/hours') {
+      //let the peasant pass
+      next();
+    } else {
+      //send to get auth
+      res.redirect('/hours');
+    }
+  }
+});
 
-// //Hours Redirected
-// app.use('/hours/home', async (req, res, next) => {
-//   if (await inMeeting()) {
-//     //meeting is happening --> redirect
-//     res.redirect('/hours/people');
-//   }
-//   else {
-//     next();
-//   }
-// });
-// app.use('/hours/people', async (req, res, next) => {
-//   if (await inMeeting()) {
-//     next();
-//   }
-//   else {
-//     //meeting is over --> redirect
-//     res.redirect('/hours/home');
-//   }
-// });
-// function roundToNearest15Minutes(date) {
-//   return date.minute(Math.round(date.minute()  / 15) * 15).second(0).millisecond(0);
-// }
-// async function inMeeting() {
-//   const taskKey = datastore.key(['person', 'Meeting']);
-//   const [entity] = await datastore.get(taskKey);
-//   const history = entity.history;
+//Hours Redirected
+app.use('/hours/home', async (req, res, next) => {
+  if (await inMeeting()) {
+    //meeting is happening --> redirect
+    res.redirect('/hours/people');
+  }
+  else {
+    next();
+  }
+});
+app.use('/hours/people', async (req, res, next) => {
+  if (await inMeeting()) {
+    next();
+  }
+  else {
+    //meeting is over --> redirect
+    res.redirect('/hours/home');
+  }
+});
+function roundToNearest15Minutes(date) {
+  return date.minute(Math.round(date.minute()  / 15) * 15).second(0).millisecond(0);
+}
+async function inMeeting() {
+  const taskKey = datastore.key(['person', 'Meeting']);
+  const [entity] = await datastore.get(taskKey);
+  const history = entity.history;
 
-//   if (history.length > 1) {
-//     const startOfLastMeetingDate = dayjs.tz(dayjs(history[history.length - 2]));
-//     const endOfLastMeetingDate = dayjs.tz(dayjs(history[history.length - 1]));
-//     const currentDate = dayjs.tz(roundToNearest15Minutes(dayjs()));
+  if (history.length > 1) {
+    const startOfLastMeetingDate = dayjs.tz(dayjs(history[history.length - 2]));
+    const endOfLastMeetingDate = dayjs.tz(dayjs(history[history.length - 1]));
+    const currentDate = dayjs.tz(roundToNearest15Minutes(dayjs()));
 
-//     return currentDate >= startOfLastMeetingDate && currentDate <= endOfLastMeetingDate;
-//   }
-//   else {
-//     return false;
-//   }
-// }
+    return currentDate >= startOfLastMeetingDate && currentDate <= endOfLastMeetingDate;
+  }
+  else {
+    return false;
+  }
+}
 
 
 
@@ -167,166 +167,166 @@ var pages = {
 //   }
 // }
 
-// //Hours People Injection
-// async function getPeopleInjection() {
-//   try {
-//     // const query = datastore.createQuery('person').select('__key__');
-//     // const result = (await datastore.runQuery(query))[0];
-//     const query = datastore.createQuery('person');
-//     const [result] = await datastore.runQuery(query);
+//Hours People Injection
+async function getPeopleInjection() {
+  try {
+    // const query = datastore.createQuery('person').select('__key__');
+    // const result = (await datastore.runQuery(query))[0];
+    const query = datastore.createQuery('person');
+    const [result] = await datastore.runQuery(query);
 
-//     const people = [];
-//     let meeting;
+    const people = [];
+    let meeting;
 
-//     //convert list of object array with name + history into name + hours
-//     for (const person of result) {
-//       const history = person.history;
-//       const name = person[datastore.KEY].name;
+    //convert list of object array with name + history into name + hours
+    for (const person of result) {
+      const history = person.history;
+      const name = person[datastore.KEY].name;
 
 
 
-//       //calculate hours
-//       let totalMs = 0;
-//       let errorFlag = false;
-//       let extraHours = 0;
-//       const isMeeting = name === "Meeting";
-//       for (let i = 0; i < history.length - 1; i += 2) {
-//         if (history[i] !== null && history[i + 1] !== null) {
-//           const startDate = dayjs.tz(dayjs(history[i]));
-//           const endDate = dayjs.tz(dayjs(history[i + 1]));
-//           const diffMs = endDate.valueOf() - startDate.valueOf();
+      //calculate hours
+      let totalMs = 0;
+      let errorFlag = false;
+      let extraHours = 0;
+      const isMeeting = name === "Meeting";
+      for (let i = 0; i < history.length - 1; i += 2) {
+        if (history[i] !== null && history[i + 1] !== null) {
+          const startDate = dayjs.tz(dayjs(history[i]));
+          const endDate = dayjs.tz(dayjs(history[i + 1]));
+          const diffMs = endDate.valueOf() - startDate.valueOf();
 
-//           if (diffMs > 24 * 3600000) {
-//             console.log(name, "potential error @", i, i + 1);
-//             errorFlag = true;
-//           }
-//           if (!(isMeeting && person.is_optional[i] && person.is_optional[i+1])) {
-//             totalMs += diffMs;
-//           }
-//         }
-//       }
+          if (diffMs > 24 * 3600000) {
+            console.log(name, "potential error @", i, i + 1);
+            errorFlag = true;
+          }
+          if (!(isMeeting && person.is_optional[i] && person.is_optional[i+1])) {
+            totalMs += diffMs;
+          }
+        }
+      }
 
-//       if (!isMeeting) {
-//         extraHours = person.extra_hours;
-//       }
+      if (!isMeeting) {
+        extraHours = person.extra_hours;
+      }
 
-//       const hours = (totalMs / 3600000) + extraHours;
+      const hours = (totalMs / 3600000) + extraHours;
       
-//       if (isMeeting) {
-//         //meeting object
-//         const startOfLastMeetingDate = dayjs.tz(dayjs(history[history.length - 2]));
-//         const endOfLastMeetingDate = dayjs.tz(dayjs(history[history.length - 1]));
-//         let meetingTitle = startOfLastMeetingDate.format('h:mm A') + ' - ' + endOfLastMeetingDate.format('h:mm A');
-//         if (person.is_optional[person.is_optional.length - 1] && person.is_optional[person.is_optional.length - 2]) {
-//           meetingTitle += " Optional"
-//         }
+      if (isMeeting) {
+        //meeting object
+        const startOfLastMeetingDate = dayjs.tz(dayjs(history[history.length - 2]));
+        const endOfLastMeetingDate = dayjs.tz(dayjs(history[history.length - 1]));
+        let meetingTitle = startOfLastMeetingDate.format('h:mm A') + ' - ' + endOfLastMeetingDate.format('h:mm A');
+        if (person.is_optional[person.is_optional.length - 1] && person.is_optional[person.is_optional.length - 2]) {
+          meetingTitle += " Optional"
+        }
 
-//         meeting = { name, hours, 
-//           title:  meetingTitle};
-//       }
-//       else {
-//       const displayHours = hours + (errorFlag ? "*" : "");
-//         //person object
-//         people.push({ name, hours: displayHours, signedIn: history.length > 0 && history[history.length - 1] === null });
-//       }
-//     }
+        meeting = { name, hours, 
+          title:  meetingTitle};
+      }
+      else {
+      const displayHours = hours + (errorFlag ? "*" : "");
+        //person object
+        people.push({ name, hours: displayHours, signedIn: history.length > 0 && history[history.length - 1] === null });
+      }
+    }
 
-//     return { people, meeting };
-//   }
-//   catch (err) {
-//     console.error(err);
-//     return { people: [], meeting: { name: "error", hours: -1 } };
-//   }
-// }
+    return { people, meeting };
+  }
+  catch (err) {
+    console.error(err);
+    return { people: [], meeting: { name: "error", hours: -1 } };
+  }
+}
 
-// //Hours Post Requests
-// app.post('/hours/person', async (req, res) => {
-//   try {
-//     if (req.body.name) {
-//       const taskKey = datastore.key(['person', req.body.name]);
-//       const [entity] = await datastore.get(taskKey);
+//Hours Post Requests
+app.post('/hours/person', async (req, res) => {
+  try {
+    if (req.body.name) {
+      const taskKey = datastore.key(['person', req.body.name]);
+      const [entity] = await datastore.get(taskKey);
   
-//       //if signed in
-//       if (entity.history.length > 0 && entity.history[entity.history.length - 1] === null) {
+      //if signed in
+      if (entity.history.length > 0 && entity.history[entity.history.length - 1] === null) {
         
-//         //then signing out
-//         console.log(req.body.name, "signing out");
-//         //get last meeting info
-//         const meetingTaskKey = datastore.key(['person', 'Meeting']);
-//         const [meetingEntity] = await datastore.get(meetingTaskKey);
-//         const endOfLastMeetingDate = dayjs.tz(dayjs(meetingEntity.history[meetingEntity.history.length - 1]));
-//         const startOfLastMeetingDate = dayjs.tz(dayjs(meetingEntity.history[meetingEntity.history.length - 2]));
-//         const startOfPersonShift = dayjs.tz(dayjs(entity.history[entity.history.length - 2]));
-//         const currentDate = dayjs.tz(dayjs());
+        //then signing out
+        console.log(req.body.name, "signing out");
+        //get last meeting info
+        const meetingTaskKey = datastore.key(['person', 'Meeting']);
+        const [meetingEntity] = await datastore.get(meetingTaskKey);
+        const endOfLastMeetingDate = dayjs.tz(dayjs(meetingEntity.history[meetingEntity.history.length - 1]));
+        const startOfLastMeetingDate = dayjs.tz(dayjs(meetingEntity.history[meetingEntity.history.length - 2]));
+        const startOfPersonShift = dayjs.tz(dayjs(entity.history[entity.history.length - 2]));
+        const currentDate = dayjs.tz(dayjs());
 
 
-//         console.log("current date: " + currentDate.format());
-//         console.log("end of last meeting: " + endOfLastMeetingDate.format());
-//         console.log("start of last meeting: " + startOfLastMeetingDate.format());
-//         console.log("start of person's shift: " + startOfPersonShift.format());
-//         if (((currentDate.diff(endOfLastMeetingDate)) < (15*60000)) && !(startOfLastMeetingDate.isAfter(startOfPersonShift))) {
-//           entity.history[entity.history.length - 1] = dayjs.tz(roundToNearest15Minutes(dayjs())).format();
-//           console.log(req.body.name, "signed out successfully");
-//         } else {
-//           entity.history[entity.history.length - 1] = entity.history[entity.history.length - 2];
-//           console.log(req.body.name, "signed out | time voided due to overrun");
-//         }
+        console.log("current date: " + currentDate.format());
+        console.log("end of last meeting: " + endOfLastMeetingDate.format());
+        console.log("start of last meeting: " + startOfLastMeetingDate.format());
+        console.log("start of person's shift: " + startOfPersonShift.format());
+        if (((currentDate.diff(endOfLastMeetingDate)) < (15*60000)) && !(startOfLastMeetingDate.isAfter(startOfPersonShift))) {
+          entity.history[entity.history.length - 1] = dayjs.tz(roundToNearest15Minutes(dayjs())).format();
+          console.log(req.body.name, "signed out successfully");
+        } else {
+          entity.history[entity.history.length - 1] = entity.history[entity.history.length - 2];
+          console.log(req.body.name, "signed out | time voided due to overrun");
+        }
         
-//       }
-//       else {
-//         console.log(req.body.name, "signed in");
-//         //else signing in
-//         entity.history.push(dayjs.tz(roundToNearest15Minutes(dayjs())).format());
-//         entity.history.push(null);
-//       }
-//       await datastore.update({ key: taskKey, data: entity });
+      }
+      else {
+        console.log(req.body.name, "signed in");
+        //else signing in
+        entity.history.push(dayjs.tz(roundToNearest15Minutes(dayjs())).format());
+        entity.history.push(null);
+      }
+      await datastore.update({ key: taskKey, data: entity });
   
-//       res.status(200).json({ success: true });
-//       return;
-//     }
-//     else {
-//       res.status(400).json({ success: false, error: "missing name" });
-//       return;
-//     }
-//   }
-//   catch (err) {
-//     console.error(err);
-//     res.status(500).json({ success: false, error: err });
-//   }
-// });
-// app.post('/hours/meeting', async (req, res) => {
-//   try {
-//     const startDate = roundToNearest15Minutes(dayjs(req.body.startDate));
-//     const endDate = roundToNearest15Minutes(dayjs(req.body.endDate));
-//     const isOptionalMeeting = req.body.isOptionalMeeting;
+      res.status(200).json({ success: true });
+      return;
+    }
+    else {
+      res.status(400).json({ success: false, error: "missing name" });
+      return;
+    }
+  }
+  catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: err });
+  }
+});
+app.post('/hours/meeting', async (req, res) => {
+  try {
+    const startDate = roundToNearest15Minutes(dayjs(req.body.startDate));
+    const endDate = roundToNearest15Minutes(dayjs(req.body.endDate));
+    const isOptionalMeeting = req.body.isOptionalMeeting;
 
 
-//     if (startDate.isValid() && endDate.isValid() && startDate < endDate) {
-//       const taskKey = datastore.key(['person', 'Meeting']);
-//       const [entity] = await datastore.get(taskKey);
+    if (startDate.isValid() && endDate.isValid() && startDate < endDate) {
+      const taskKey = datastore.key(['person', 'Meeting']);
+      const [entity] = await datastore.get(taskKey);
 
-//       entity.history.push(startDate.format());
-//       entity.history.push(endDate.format());
-//       entity.is_optional.push(isOptionalMeeting);
-//       entity.is_optional.push(isOptionalMeeting);
+      entity.history.push(startDate.format());
+      entity.history.push(endDate.format());
+      entity.is_optional.push(isOptionalMeeting);
+      entity.is_optional.push(isOptionalMeeting);
 
-//       console.log("created new meeting from ", startDate.format("h:m A"), " to ", endDate.format("h:m A"));
+      console.log("created new meeting from ", startDate.format("h:m A"), " to ", endDate.format("h:m A"));
   
-//       await datastore.update({ key: taskKey, data: entity });
+      await datastore.update({ key: taskKey, data: entity });
   
-//       res.status(200).json({ success: true });;
-//       return;
-//     }
-//     else {
-//       res.status(400).json({ success: false, error: "invalid dates" });
-//       return;
-//     }
-//   }
-//   catch (err) {
-//     console.error(err);
-//     res.status(500).json({ success: false, error: err });
-//   }
-// });
+      res.status(200).json({ success: true });;
+      return;
+    }
+    else {
+      res.status(400).json({ success: false, error: "invalid dates" });
+      return;
+    }
+  }
+  catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: err });
+  }
+});
 
 //Serve Page
 app.get(Object.keys(pages), async (req, res) => {

--- a/server.js
+++ b/server.js
@@ -118,7 +118,7 @@ app.use('/hours/people', async (req, res, next) => {
   }
 });
 function roundToNearest15Minutes(date) {
-  return date.minute(Math.round(date.minute()  / 15) * 15).second(0).millisecond(0);
+  return date;
 }
 async function inMeeting() {
   const taskKey = datastore.key(['person', 'Meeting']);
@@ -295,37 +295,8 @@ app.post('/hours/person', async (req, res) => {
   }
 });
 app.post('/hours/meeting', async (req, res) => {
-  try {
-    const startDate = roundToNearest15Minutes(dayjs(req.body.startDate));
-    const endDate = roundToNearest15Minutes(dayjs(req.body.endDate));
-    const isOptionalMeeting = req.body.isOptionalMeeting;
-
-
-    if (startDate.isValid() && endDate.isValid() && startDate < endDate) {
-      const taskKey = datastore.key(['person', 'Meeting']);
-      const [entity] = await datastore.get(taskKey);
-
-      entity.history.push(startDate.format());
-      entity.history.push(endDate.format());
-      entity.is_optional.push(isOptionalMeeting);
-      entity.is_optional.push(isOptionalMeeting);
-
-      console.log("created new meeting from ", startDate.format("h:m A"), " to ", endDate.format("h:m A"));
-  
-      await datastore.update({ key: taskKey, data: entity });
-  
-      res.status(200).json({ success: true });;
-      return;
-    }
-    else {
-      res.status(400).json({ success: false, error: "invalid dates" });
-      return;
-    }
-  }
-  catch (err) {
-    console.error(err);
-    res.status(500).json({ success: false, error: err });
-  }
+  res.status(200).json({ success: true });;
+  return;
 });
 
 //Serve Page

--- a/src/pages/hours/people.html
+++ b/src/pages/hours/people.html
@@ -17,18 +17,16 @@
     <card>
         <img src="/images/icon.png">
         <card-title>Hours Tracker</card-title>
-        <card-subtitle><%= meeting.title %> Meeting</card-subtitle>
+	<!--<card-subtitle><%= meeting.title %> Meeting</card-subtitle>-->
         <card-subtitle><%= date %></card-subtitle>
         <table class="people-table">
             <tr>
                 <th>Name</th>
-                <th>Hours</th>
                 <th style="width:120px;"></th>
             </tr>
             <% for (const person of people) { %>
             <tr>
                 <td><%= person.name %></td>
-                <td><%= person.hours %></td>
                 <td>
                     <button type="button"
                         class="btn <%= person.signedIn ? 'btn-secondary' : 'btn-primary' %>" 
@@ -38,14 +36,6 @@
                 </td>
             </tr>
             <% } %>
-            <tr>
-                <td>2/3 of total</td>
-                <td><%= meeting.hours * 2/3%></td>
-            </tr>
-            <tr>
-                <td>Total</td>
-                <td><%= meeting.hours %></td>
-            </tr>
         </table>
     </card>
 


### PR DESCRIPTION
Re-enables hours tracking on the prod site as per current dev site functionality.

Changes from old hours tracking:
- Hours are tracked using a single long meeting as a workaround
- No rounding is performed for sign in/out times
- No hours display (will be added)